### PR TITLE
fix: prevent endless re-renders for main component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gifted-chat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The most complete chat UI for React Native",
   "main": "index.js",
   "engines": {

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -448,6 +448,30 @@ class GiftedChat extends React.Component {
     return null;
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    if (!_.isEqual(this.state, nextState)) {
+      return true;
+    }
+
+    if (this.props.loadEarlier !== nextProps.loadEarlier) {
+      return true;
+    }
+
+    if (this.props.isLoadingEarlier !== nextProps.isLoadingEarlier) {
+      return true;
+    }
+
+    if (this.props.shouldHideInputToolbar !== nextProps.shouldHideInputToolbar) {
+      return true;
+    }
+
+    if (!_.isEqual(this.props.messages, nextProps.messages)) {
+      return true;
+    }
+
+    return false;
+  }
+
   render() {
     const minHeight = Math.max(this.state.composerHeight || 0) + (this.state.suggestionsHeight || 0) + 10;
     if (this.state.isInitialized === true) {


### PR DESCRIPTION
Due to some weird issue one some Android phones (Kenneth's LG), the gifted chat component goes on an endless re-render loop. Added shouldComponentUpdate to prevent this behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edtechfoundry/react-native-gifted-messenger/26)
<!-- Reviewable:end -->
