### PR TITLE
fix(input-toolbar): do not account for toolbar height if it is hidden

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -197,7 +197,15 @@ class GiftedChat extends React.Component {
   // TODO
   // setMinInputToolbarHeight
   getMinInputToolbarHeight() {
-    return this.props.renderAccessory ? this.props.minInputToolbarHeight * 2 : this.props.minInputToolbarHeight;
+    if (this.props.shouldHideInputToolbar) {
+      return 0;
+    } else {
+      if (this.props.renderAccessory) {
+        return this.props.minInputToolbarHeight * 2
+      } else {
+        return this.props.minInputToolbarHeight;
+      }
+    }
   }
 
   prepareMessagesContainerHeight(value) {


### PR DESCRIPTION
Relates to #DIF-1916

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edtechfoundry/react-native-gifted-messenger/27)
<!-- Reviewable:end -->
