### PR TITLE
fix: set the correct height of the chat when hiding/showing input

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -114,6 +114,11 @@ class GiftedChat extends React.Component {
 
   componentWillReceiveProps(nextProps = {}) {
     this.initMessages(nextProps.messages);
+    if (this.props.shouldHideInputToolbar !== nextProps.shouldHideInputToolbar) {
+      this.setState({
+        messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight(nextProps) - this.getKeyboardHeight() + this.getBottomOffset()),
+      });
+    }
   }
 
   initLocale() {
@@ -196,14 +201,14 @@ class GiftedChat extends React.Component {
 
   // TODO
   // setMinInputToolbarHeight
-  getMinInputToolbarHeight() {
-    if (this.props.shouldHideInputToolbar) {
+  getMinInputToolbarHeight(props = this.props) {
+    if (props.shouldHideInputToolbar) {
       return 0;
     } else {
-      if (this.props.renderAccessory) {
-        return this.props.minInputToolbarHeight * 2
+      if (props.renderAccessory) {
+        return props.minInputToolbarHeight * 2
       } else {
-        return this.props.minInputToolbarHeight;
+        return props.minInputToolbarHeight;
       }
     }
   }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edtechfoundry/react-native-gifted-messenger/29)
<!-- Reviewable:end -->
