### PR TITLE
fix: make sure load more rerenders when loadEarlier prop changes

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -115,6 +115,10 @@ export default class MessageContainer extends React.Component {
   keyExtractor = (item, index) => item._id;
 
   render() {
+    const {extraData, ...restFlatListProps} = this.props.flatListProps;
+    const mergedExtraData = Object.assign({}, extraData, {
+      loadEarlier: this.props.loadEarlier,
+    });
     return (
       <View ref='container' style={{flex: 1}}>
         <FlatList
@@ -123,7 +127,8 @@ export default class MessageContainer extends React.Component {
           automaticallyAdjustContentInsets={false}
           initialNumToRender={20}
           {...this.props.flatListKeyboardProps}
-          {...this.props.flatListProps}
+          {...restFlatListProps}
+          extraData={mergedExtraData}
           data={this.state.messages}
           keyExtractor={this.keyExtractor}
           renderItem={this.renderRow}


### PR DESCRIPTION
To make sure the load more label/spinner shows up or disappears when it should, extra data has to be passed along to the flatlist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edtechfoundry/react-native-gifted-messenger/39)
<!-- Reviewable:end -->
